### PR TITLE
Fix FTP directory creation race

### DIFF
--- a/scrapy/utils/ftp.py
+++ b/scrapy/utils/ftp.py
@@ -13,7 +13,12 @@ def ftp_makedirs_cwd(ftp: FTP, path: str, first_call: bool = True) -> None:
         ftp.cwd(path)
     except error_perm:
         ftp_makedirs_cwd(ftp, dirname(path), False)
-        ftp.mkd(path)
+        try:
+            ftp.mkd(path)
+        except error_perm as exc:
+            # ignore "directory already exists" errors
+            if not str(exc).startswith("550"):
+                raise
         if first_call:
             ftp.cwd(path)
 

--- a/tests/test_utils_ftp.py
+++ b/tests/test_utils_ftp.py
@@ -1,0 +1,28 @@
+import io
+from ftplib import FTP, error_perm
+from unittest import mock
+
+from scrapy.utils.ftp import ftp_store_file
+from tests.mockserver import MockFTPServer
+
+
+def test_ftp_makedirs_ignore_existing_dir():
+    with MockFTPServer() as ftp_server:
+        orig_mkd = FTP.mkd
+
+        def mkd_then_exists(self, path):
+            # create the directory then behave as if it already existed
+            orig_mkd(self, path)
+            raise error_perm("550 File exists.")
+
+        with mock.patch("ftplib.FTP.mkd", new=mkd_then_exists):
+            ftp_store_file(
+                path="dir/subdir/file",
+                file=io.BytesIO(b"data"),
+                host="127.0.0.1",
+                port=2121,
+                username="",
+                password="",
+            )
+        assert (ftp_server.path / "dir/subdir/file").read_bytes() == b"data"
+


### PR DESCRIPTION
## Summary
- handle "directory already exists" errors in `ftp_makedirs_cwd`
- add regression test for concurrent directory creation

## Testing
- `pytest tests/test_utils_ftp.py tests/test_feedexport.py::TestFTPFeedStorage -q`

------
https://chatgpt.com/codex/tasks/task_e_6877de78097c833393b12cb43f3f178b